### PR TITLE
Small, mostly-QoL changes

### DIFF
--- a/bot/cmd.py
+++ b/bot/cmd.py
@@ -37,6 +37,9 @@ class Context(commands.Context):
         if "reference" not in kwargs and can_read_history:
             kwargs = dict(kwargs, reference=self.message)
 
+        if embed := kwargs.get("embed") and embed.color is discord.Embed.Empty:
+            embed.color = 0x58b9ff
+
         return await super().send(content, **kwargs)
 
     async def prompt(

--- a/bot/ext/utilities.py
+++ b/bot/ext/utilities.py
@@ -223,6 +223,7 @@ class Utilities(cmd.Cog):
 
     @commands.group(invoke_without_command=True)
     @commands.cooldown(4, 4, commands.BucketType.member)
+    @commands.guild_only()
     async def icon(self, ctx: cmd.Context):
         """Gives the URL to the server's icon"""
 
@@ -236,6 +237,7 @@ class Utilities(cmd.Cog):
 
     @icon.command(name="static")
     @commands.cooldown(4, 4, commands.BucketType.member)
+    @commands.guild_only()
     async def icon_static(self, ctx: cmd.Context):
         """Gives the URL to the server's non-animated icon"""
 

--- a/bot/ext/webhooks.py
+++ b/bot/ext/webhooks.py
@@ -28,11 +28,14 @@ class Webhooks(cmd.Cog):
             value=f"{webhook.created_at.ctime()} UTC".replace("  ", " "),
         )
 
-        url_message = (
-            webhook.url
-            if show_url
-            else f"Use {get_command_signature(ctx, self.webhook_url)} to obtain the URL."
-        )
+        if webhook.token:
+            url_message = (
+                webhook.url
+                if show_url
+                else f"Use {get_command_signature(ctx, self.webhook_url)} to obtain the URL."
+            )
+        else:
+            url_message = "This webhook was created by a bot other than myself, so I cannot get its full URL."
         embed.add_field(name="Webhook URL", value=url_message, inline=False)
 
         return embed
@@ -190,6 +193,15 @@ class Webhooks(cmd.Cog):
         if not channel_perms.view_channel or not channel_perms.manage_webhooks:
             raise commands.BotMissingPermissions(["manage_webhooks"])
 
+        if not webhook.token:
+            await ctx.prompt(
+                embed=discord.Embed(
+                    title="Unable to edit",
+                    description="This webhook was created by a bot other than myself, so I cannot edit it."
+                )
+            )
+            return
+
         edit_kwargs = {}
 
         if new_name:
@@ -227,6 +239,15 @@ class Webhooks(cmd.Cog):
         channel_perms = webhook.channel.permissions_for(ctx.me)
         if not channel_perms.view_channel or not channel_perms.manage_webhooks:
             raise commands.BotMissingPermissions(["manage_webhooks"])
+
+        if not webhook.token:
+            await ctx.prompt(
+                embed=discord.Embed(
+                    title="Unable to delete",
+                    description="This webhook was created by a bot other than myself, so I cannot delete it."
+                )
+            )
+            return
 
         prompt = menus.ConfirmationPrompt(
             self.bot,

--- a/bot/ext/webhooks.py
+++ b/bot/ext/webhooks.py
@@ -117,6 +117,15 @@ class Webhooks(cmd.Cog):
         if not channel_perms.view_channel or not channel_perms.manage_webhooks:
             raise commands.BotMissingPermissions(["manage_webhooks"])
 
+        if not webhook.token:
+            await ctx.prompt(
+                embed=discord.Embed(
+                    title="Unable to get URL",
+                    description="This webhook was created by a bot other than myself, so I cannot get its full URL."
+                )
+            )
+            return
+
         try:
             await ctx.author.send(
                 embed=self.get_webhook_embed(ctx, webhook, show_url=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp==3.6.3
 asyncpg==0.21.0
 black==20.8b1
 cachetools==4.1.1
-discord.py==1.7.2
+discord.py==1.7.3
 jishaku==1.20.0.220
 pg8000==1.16.6
 psutil==5.7.3


### PR DESCRIPTION
• `d.icon` should be guild-only (is it tomorrow already?)
• Respond specially if the webhook mentioned in `d.webhook url` is created by a bot (or Discobot is otherwise unable to get its token)
• Set the embed color, if not otherwise set, to the Discohook brand color (#58b9ff)
• Bump discord.py version requirement due to a sticker-related crash