### PR TITLE
Added support for message links that use the domain "discordapp.com"

### DIFF
--- a/src/lib/messages/parseMessageOption.ts
+++ b/src/lib/messages/parseMessageOption.ts
@@ -8,7 +8,7 @@ export const parseMessageOption = async (
   const query = interaction.options.getString(messageOptionName, true)
 
   const result =
-      /^https?:\/\/(?:www\.|ptb\.|canary\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)$/.exec(
+    /^https?:\/\/(?:www\.|ptb\.|canary\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)$/.exec(
       query,
     )
 

--- a/src/lib/messages/parseMessageOption.ts
+++ b/src/lib/messages/parseMessageOption.ts
@@ -8,7 +8,7 @@ export const parseMessageOption = async (
   const query = interaction.options.getString(messageOptionName, true)
 
   const result =
-    /^https?:\/\/(?:www\.|ptb\.|canary\.)?discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)$/.exec(
+      /^https?:\/\/(?:www\.|ptb\.|canary\.)?discord(?:app)?\.com\/channels\/(\d+)\/(\d+)\/(\d+)$/.exec(
       query,
     )
 


### PR DESCRIPTION
- discordapp.com is a domain owned by discord that redirects to discord.com
- This domain is still used by some clients when selecting "Copy Message Link" or "Copy Webhook URL"
- Support for the discordapp.com domain is supported by the discohook site:
  -  Regex constant defined as `WEBHOOK_URL_RE` in [site/modules/webhook/constants.ts](https://github.com/discohook/site/blob/b836e0f96d609a5911349909b551aa6709db1150/modules/webhook/constants.ts#L36)